### PR TITLE
Add sphinx and doxygen dependencies of muscat-devenv

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -174,6 +174,8 @@ outputs:
         - mmgsuite =5.8
         - pycgns-core
         - cvxpy  # [not osx or py!=313 ]
+        - sphinx
+        - doxygen
     test:
       imports:
         - numpy


### PR DESCRIPTION
Add sphinx and doxygen as dependencies of muscat-devenv in meta.yaml

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.


I needed to install these in addition to muscat-devenv to be able to complile muscat, from a clean env on a clean workspace on AWS.


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
